### PR TITLE
Upgrade google dependencies to use gradle instead of deprecated Cordova plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,8 +40,7 @@
             <service android:name="com.zendrive.sdk.services.ZendriveService" />
         </config-file>
 
-        <dependency id="com.google.playservices" />
-        <dependency id="android.support.v4" />
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 
         <source-file src="src/android/com/zendrive/phonegap/ZendriveCordovaPlugin.java" target-dir="src/com/zendrive/phonegap" />
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,14 @@
+repositories{    
+  jcenter()
+}
+
+android {
+	packagingOptions {
+		exclude 'META-INF/LICENSE.txt'
+	}
+}
+
+dependencies {
+    compile 'com.google.android.gms:play-services-location:+'
+    compile 'com.android.support:support-v4:+'
+}


### PR DESCRIPTION
Upgrade google dependencies to use **gradle** instead of **deprecated Cordova plugins**.  Welcome to 2016.

This is especially important for the `play-services` dependency, since the plugin is including the **ENTIRE**, immense `play-services` lib when it only requires `play-services-location`.  This is like taking your entire bookshelf on vacation when you're only going to read 1 book.  

In addition, the Cordova plugin [com.google.playservices](https://github.com/MobileChromeApps/google-play-services) README is clearly marked as **deprecated**, instructing users to include their dependency in the manner which this commit implements.

![](https://www.dropbox.com/s/vapz2d7tin5heyv/Screenshot%202016-01-22%2006.07.55.png?dl=1)

I had another issue with build this plugin which required adding a directive to the `build.gradle` file in the pull-request.  I'd rather not have to do this:
```
android {
	packagingOptions {
		exclude 'META-INF/LICENSE.txt'
	}
}
```

Without the directive above, the following error occurs:

```
Error: duplicate files during packaging of APK /Users/chris/Documents/workspace/cordova/ionic-background-geolocation/platforms/android/build/outputs/apk/android-debug-unaligned.apk
	Path in archive: META-INF/LICENSE.txt
	Origin 1: /Users/chris/Documents/workspace/cordova/ionic-background-geolocation/platforms/android/libs/ebson-0.4-20140612.044330-1.jar
	Origin 2: /Users/chris/Documents/workspace/cordova/ionic-background-geolocation/platforms/android/libs/libthrift-0.9.1.jar
You can ignore those files in your build.gradle:
	android {
	  packagingOptions {
	    exclude 'META-INF/LICENSE.txt'
	  }
	}
```

Please rebuild your jars to fix this problem.